### PR TITLE
replace moin moin link with link to pelican project

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,5 +22,5 @@ The following changes have been made relative to a plain Pelican project.  If us
 
 ## References
 
-* [Moin Moin](https://moinmo.in/)
+* [Pelican](https://getpelican.com/)
 * [Python on Platform.sh](https://docs.platform.sh/languages/python.html)


### PR DESCRIPTION
Fixes a wrong link in the README of the project.